### PR TITLE
Fix android crash in TurboImage by minimizing the number of active network listeners.

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -96,6 +96,6 @@ dependencies {
   implementation "io.coil-kt:coil-svg:2.6.0"
   implementation "com.github.Commit451.coil-transformations:transformations:2.0.2"
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-  implementation("com.linecorp:apng:1.11.0")
+  implementation("com.linecorp:apng:1.12.0")
 }
 

--- a/android/src/main/java/com/turboimage/ImageLoaderProvider.kt
+++ b/android/src/main/java/com/turboimage/ImageLoaderProvider.kt
@@ -1,0 +1,43 @@
+package com.turboimage
+
+import android.content.Context
+import coil.ImageLoader
+import okhttp3.OkHttpClient
+import com.turboimage.events.interceptor.ProgressInterceptor
+
+object ImageLoaderProvider {
+  @Volatile private var defaultLoader: ImageLoader? = null
+  @Volatile private var urlCacheLoader: ImageLoader? = null
+
+  private fun buildOkHttpClient(): OkHttpClient {
+    return OkHttpClient.Builder()
+      .addInterceptor(ProgressInterceptor())
+      .build()
+  }
+
+  private fun buildImageLoader(
+    context: Context,
+    respectCacheHeaders: Boolean,
+    observerEnabled: Boolean
+  ): ImageLoader {
+    return ImageLoader.Builder(context)
+      .okHttpClient(buildOkHttpClient())
+      .respectCacheHeaders(respectCacheHeaders)
+      .networkObserverEnabled(observerEnabled)
+      .build()
+  }
+
+  fun get(context: Context, respectCacheHeaders: Boolean): ImageLoader {
+    return if (respectCacheHeaders) {
+      urlCacheLoader ?: synchronized(this) {
+        urlCacheLoader ?: buildImageLoader(context, true, true).also { urlCacheLoader = it }
+      }
+    } else {
+      defaultLoader ?: synchronized(this) {
+        defaultLoader ?: buildImageLoader(context, false, true).also { defaultLoader = it }
+      }
+    }
+  }
+}
+
+

--- a/android/src/main/java/com/turboimage/ImageLoaderProvider.kt
+++ b/android/src/main/java/com/turboimage/ImageLoaderProvider.kt
@@ -9,8 +9,8 @@ object ImageLoaderProvider {
   @Volatile private var defaultLoader: ImageLoader? = null
   @Volatile private var urlCacheLoader: ImageLoader? = null
 
-  private fun buildOkHttpClient(): OkHttpClient {
-    return OkHttpClient.Builder()
+  private val sharedOkHttpClient: OkHttpClient by lazy {
+    OkHttpClient.Builder()
       .addInterceptor(ProgressInterceptor())
       .build()
   }
@@ -18,10 +18,10 @@ object ImageLoaderProvider {
   private fun buildImageLoader(
     context: Context,
     respectCacheHeaders: Boolean,
-    observerEnabled: Boolean
+    observerEnabled: Boolean = true
   ): ImageLoader {
     return ImageLoader.Builder(context)
-      .okHttpClient(buildOkHttpClient())
+      .okHttpClient(sharedOkHttpClient)
       .respectCacheHeaders(respectCacheHeaders)
       .networkObserverEnabled(observerEnabled)
       .build()

--- a/android/src/main/java/com/turboimage/TurboImageListener.kt
+++ b/android/src/main/java/com/turboimage/TurboImageListener.kt
@@ -73,4 +73,9 @@ class TurboImageListener(private val view: TurboImageView, private val onComplet
 
     onComplete?.invoke()
   }
+
+  override fun onCancel(request: ImageRequest) {
+    super.onCancel(request)
+    onComplete?.invoke()
+  }
 }

--- a/android/src/main/java/com/turboimage/TurboImageListener.kt
+++ b/android/src/main/java/com/turboimage/TurboImageListener.kt
@@ -11,7 +11,7 @@ import com.turboimage.events.FailureEvent
 import com.turboimage.events.StartEvent
 import com.turboimage.events.SuccessEvent
 
-class TurboImageListener(private val view: TurboImageView) : ImageRequest.Listener {
+class TurboImageListener(private val view: TurboImageView, private val onComplete: (() -> Unit)? = null) : ImageRequest.Listener {
 
   override fun onStart(request: ImageRequest) {
     super.onStart(request)
@@ -47,6 +47,8 @@ class TurboImageListener(private val view: TurboImageView) : ImageRequest.Listen
       val surfaceId = UIManagerHelper.getSurfaceId(reactContext)
       it.dispatchEvent(CompletionEvent(surfaceId, view.id, payload))
     }
+
+    onComplete?.invoke()
   }
 
   override fun onError(request: ImageRequest, result: ErrorResult) {
@@ -68,5 +70,7 @@ class TurboImageListener(private val view: TurboImageView) : ImageRequest.Listen
       val surfaceId = UIManagerHelper.getSurfaceId(reactContext)
       it.dispatchEvent(CompletionEvent(surfaceId, view.id, payload))
     }
+
+    onComplete?.invoke()
   }
 }

--- a/android/src/main/java/com/turboimage/TurboImageModule.kt
+++ b/android/src/main/java/com/turboimage/TurboImageModule.kt
@@ -51,9 +51,7 @@ class TurboImageModule(private val context: ReactApplicationContext) :
           .build()
       }
     }
-    imageLoader = Coil.imageLoader(context).newBuilder()
-      .respectCacheHeaders(cachePolicy == "urlCache")
-      .build()
+    imageLoader = ImageLoaderProvider.get(context, cachePolicy == "urlCache")
     imageRequests.forEach { imageRequest ->
       imageLoader?.enqueue(imageRequest)
     }

--- a/android/src/main/java/com/turboimage/TurboImageView.kt
+++ b/android/src/main/java/com/turboimage/TurboImageView.kt
@@ -54,6 +54,8 @@ class TurboImageView(private val reactContext: ThemedReactContext) :
 
   var memoryCacheKey: String? = null
 
+  var currentProgressId: String? = null
+
   val circleProgressDrawable: CircularProgressDrawable?
     get() {
       indicator.let {

--- a/android/src/main/java/com/turboimage/TurboImageViewManager.kt
+++ b/android/src/main/java/com/turboimage/TurboImageViewManager.kt
@@ -87,7 +87,6 @@ class TurboImageViewManager : SimpleViewManager<TurboImageView>(), LifecycleEven
     val imageLoader = ImageLoaderProvider.get(view.context, view.cachePolicy == "urlCache")
 
     view.load(view.uri, imageLoader) {
-      view.headers?.let { headers(it) }
       view.cacheKey?.let {
         memoryCacheKey(it)
         diskCacheKey(it)
@@ -146,7 +145,7 @@ class TurboImageViewManager : SimpleViewManager<TurboImageView>(), LifecycleEven
       // attach progress id so interceptor can route updates
       headers(
         (view.headers ?: Headers.Builder().build()).newBuilder()
-          .add(ProgressInterceptor.PROGRESS_ID_HEADER, progressId)
+          .set(ProgressInterceptor.PROGRESS_ID_HEADER, progressId)
           .build()
       )
 

--- a/android/src/main/java/com/turboimage/TurboImageViewManager.kt
+++ b/android/src/main/java/com/turboimage/TurboImageViewManager.kt
@@ -3,7 +3,6 @@ package com.turboimage
 import android.graphics.drawable.BitmapDrawable
 import android.os.Build.VERSION.SDK_INT
 import android.widget.ImageView.ScaleType
-import coil.Coil
 import coil.decode.GifDecoder
 import coil.decode.ImageDecoderDecoder
 import coil.decode.SvgDecoder
@@ -26,9 +25,9 @@ import com.facebook.react.uimanager.annotations.ReactProp
 import okhttp3.Headers
 import com.turboimage.decoder.APNGDecoder
 import com.turboimage.events.ProgressEvent
+import java.util.UUID
 import com.turboimage.events.interceptor.ProgressInterceptor
-import com.turboimage.events.interceptor.ProgressListener
-import okhttp3.OkHttpClient
+import com.turboimage.events.interceptor.ProgressRegistry
 
 class TurboImageViewManager : SimpleViewManager<TurboImageView>(), LifecycleEventListener {
   override fun getName() = REACT_CLASS
@@ -68,26 +67,20 @@ class TurboImageViewManager : SimpleViewManager<TurboImageView>(), LifecycleEven
       CrossfadeDrawable.DEFAULT_DURATION
     }
 
-    val okHttpClient = OkHttpClient.Builder()
-      .addInterceptor(ProgressInterceptor(object : ProgressListener {
-        override fun update(bytesRead: Long, contentLength: Long, done: Boolean) {
-          val reactContext = view.context as ReactContext
-          UIManagerHelper.getEventDispatcher(reactContext, view.id)?.let {
-            val payload = Arguments.createMap().apply {
-              putDouble("completed", bytesRead.toDouble())
-              putDouble("total", contentLength.toDouble())
-            }
-            val surfaceId = UIManagerHelper.getSurfaceId(reactContext)
-            it.dispatchEvent(ProgressEvent(surfaceId, view.id, payload))
-          }
+    val progressId = UUID.randomUUID().toString()
+    ProgressRegistry.register(progressId) { bytesRead, contentLength, _ ->
+      val reactContext = view.context as ReactContext
+      UIManagerHelper.getEventDispatcher(reactContext, view.id)?.let {
+        val payload = Arguments.createMap().apply {
+          putDouble("completed", bytesRead.toDouble())
+          putDouble("total", contentLength.toDouble())
         }
-      }))
-      .build()
+        val surfaceId = UIManagerHelper.getSurfaceId(reactContext)
+        it.dispatchEvent(ProgressEvent(surfaceId, view.id, payload))
+      }
+    }
 
-    val imageLoader = Coil.imageLoader(view.context).newBuilder()
-      .respectCacheHeaders(view.cachePolicy == "urlCache")
-      .okHttpClient(okHttpClient)
-      .build()
+    val imageLoader = ImageLoaderProvider.get(view.context, view.cachePolicy == "urlCache")
 
     view.load(view.uri, imageLoader) {
       view.headers?.let { headers(it) }
@@ -96,7 +89,9 @@ class TurboImageViewManager : SimpleViewManager<TurboImageView>(), LifecycleEven
         diskCacheKey(it)
       }
       view.allowHardware?.let { allowHardware(it) }
-      listener(TurboImageListener(view))
+      listener(TurboImageListener(view) {
+        ProgressRegistry.unregister(progressId)
+      })
       view.format?.let {
         when (it) {
           "svg" -> {
@@ -125,9 +120,7 @@ class TurboImageViewManager : SimpleViewManager<TurboImageView>(), LifecycleEven
         }
       }
 
-      placeholder(
-        view.thumbhashDrawable ?: view.blurhashDrawable ?: view.circleProgressDrawable
-      )
+      placeholder(view.thumbhashDrawable ?: view.blurhashDrawable ?: view.circleProgressDrawable)
       view.memoryCacheKey?.let {
         placeholderMemoryCacheKey(it)
       }
@@ -143,6 +136,12 @@ class TurboImageViewManager : SimpleViewManager<TurboImageView>(), LifecycleEven
         }
       }
       size(view.resize ?: Size.ORIGINAL)
+      // attach progress id so interceptor can route updates
+      headers(
+        (view.headers ?: Headers.Builder().build()).newBuilder()
+          .add(ProgressInterceptor.PROGRESS_ID_HEADER, progressId)
+          .build()
+      )
 
     }
   }

--- a/android/src/main/java/com/turboimage/TurboImageViewManager.kt
+++ b/android/src/main/java/com/turboimage/TurboImageViewManager.kt
@@ -57,6 +57,8 @@ class TurboImageViewManager : SimpleViewManager<TurboImageView>(), LifecycleEven
 
   override fun onDropViewInstance(view: TurboImageView) {
     super.onDropViewInstance(view)
+    view.currentProgressId?.let { ProgressRegistry.unregister(it) }
+    view.currentProgressId = null
     view.dispose()
   }
 
@@ -67,7 +69,9 @@ class TurboImageViewManager : SimpleViewManager<TurboImageView>(), LifecycleEven
       CrossfadeDrawable.DEFAULT_DURATION
     }
 
+    view.currentProgressId?.let { ProgressRegistry.unregister(it) }
     val progressId = UUID.randomUUID().toString()
+    view.currentProgressId = progressId
     ProgressRegistry.register(progressId) { bytesRead, contentLength, _ ->
       val reactContext = view.context as ReactContext
       UIManagerHelper.getEventDispatcher(reactContext, view.id)?.let {
@@ -91,6 +95,9 @@ class TurboImageViewManager : SimpleViewManager<TurboImageView>(), LifecycleEven
       view.allowHardware?.let { allowHardware(it) }
       listener(TurboImageListener(view) {
         ProgressRegistry.unregister(progressId)
+        if (view.currentProgressId == progressId) {
+          view.currentProgressId = null
+        }
       })
       view.format?.let {
         when (it) {
@@ -257,11 +264,15 @@ class TurboImageViewManager : SimpleViewManager<TurboImageView>(), LifecycleEven
   }
 
   override fun onHostPause() {
+    imageView.currentProgressId?.let { ProgressRegistry.unregister(it) }
+    imageView.currentProgressId = null
     imageView.dispose()
     isInBackground = true
   }
 
   override fun onHostDestroy() {
+    imageView.currentProgressId?.let { ProgressRegistry.unregister(it) }
+    imageView.currentProgressId = null
     imageView.dispose()
   }
 }

--- a/android/src/main/java/com/turboimage/events/interceptor/ProgressInterceptor.kt
+++ b/android/src/main/java/com/turboimage/events/interceptor/ProgressInterceptor.kt
@@ -8,7 +8,7 @@ class ProgressInterceptor : Interceptor {
     val request = chain.request()
     val progressId = request.header(PROGRESS_ID_HEADER)
     val originalResponse = chain.proceed(request)
-    return if (progressId != null) {
+    return if (progressId != null && originalResponse.body != null) {
       val listener = ProgressListener { bytesRead, contentLength, done ->
         ProgressRegistry.notify(progressId, bytesRead, contentLength, done)
       }

--- a/android/src/main/java/com/turboimage/events/interceptor/ProgressInterceptor.kt
+++ b/android/src/main/java/com/turboimage/events/interceptor/ProgressInterceptor.kt
@@ -3,11 +3,24 @@ package com.turboimage.events.interceptor
 import okhttp3.Interceptor
 import okhttp3.Response
 
-class ProgressInterceptor(private val listener: ProgressListener) : Interceptor {
+class ProgressInterceptor : Interceptor {
   override fun intercept(chain: Interceptor.Chain): Response {
-    val originalResponse = chain.proceed(chain.request())
-    return originalResponse.newBuilder()
-      .body(ProgressResponseBody(originalResponse.body!!, listener))
-      .build()
+    val request = chain.request()
+    val progressId = request.header(PROGRESS_ID_HEADER)
+    val originalResponse = chain.proceed(request)
+    return if (progressId != null) {
+      val listener = ProgressListener { bytesRead, contentLength, done ->
+        ProgressRegistry.notify(progressId, bytesRead, contentLength, done)
+      }
+      originalResponse.newBuilder()
+        .body(ProgressResponseBody(originalResponse.body!!, listener))
+        .build()
+    } else {
+      originalResponse
+    }
+  }
+
+  companion object {
+    const val PROGRESS_ID_HEADER = "X-TurboImage-Progress-Id"
   }
 }

--- a/android/src/main/java/com/turboimage/events/interceptor/ProgressListener.kt
+++ b/android/src/main/java/com/turboimage/events/interceptor/ProgressListener.kt
@@ -1,5 +1,5 @@
 package com.turboimage.events.interceptor
 
-interface ProgressListener {
+fun interface ProgressListener {
   fun update(bytesRead: Long, contentLength: Long, done: Boolean)
 }

--- a/android/src/main/java/com/turboimage/events/interceptor/ProgressRegistry.kt
+++ b/android/src/main/java/com/turboimage/events/interceptor/ProgressRegistry.kt
@@ -1,0 +1,21 @@
+package com.turboimage.events.interceptor
+
+import java.util.concurrent.ConcurrentHashMap
+
+object ProgressRegistry {
+  private val progressListeners = ConcurrentHashMap<String, ProgressListener>()
+
+  fun register(progressId: String, listener: ProgressListener) {
+    progressListeners[progressId] = listener
+  }
+
+  fun unregister(progressId: String) {
+    progressListeners.remove(progressId)
+  }
+
+  fun notify(progressId: String, bytesRead: Long, contentLength: Long, done: Boolean) {
+    progressListeners[progressId]?.update(bytesRead, contentLength, done)
+  }
+}
+
+

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-turbo-image",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Performant image for React native",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-turbo-image",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Performant image for React native",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-turbo-image",
-  "version": "1.22.5",
+  "version": "1.0.2",
   "description": "Performant image for React native",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",


### PR DESCRIPTION
## Description

This PR refactors the way we handle `imageLoader` in coil to use a global singleton handler instead of creating a loader in each individual TurboImage component. The goal - to avoid creating a bunch of network listeners (which android only allows a max of 100 to be active at a time). See https://github.com/coil-kt/coil/issues/2567 for more info.

A few notes:
- When I say 1 `imageLoader`, it's actually 2: one for cache-control header images and one for non cache-control images. 
- To distinguish requests, we create a unique id for each image load and pass that to the `ProgressRegistry`.
- Since we only have 1 okhttpclient now (instead of one for each TurboImage component), the `ProgressInterceptor` no longer has a listener attached to it directly. Instead, read from the `ProgressRegistry` through the `PROGRESS_ID_HEADER` to grab the request and notify listeners of download progress.