### PR TITLE
Fix: Fix retain cycle in iOS by adding weak self to capture list

### DIFF
--- a/ios/TurboImageView.swift
+++ b/ios/TurboImageView.swift
@@ -338,32 +338,38 @@ fileprivate extension TurboImageView {
 fileprivate extension TurboImageView {
   
   func registerObservers() {
-    lazyImageView.onStart = { task in
+    lazyImageView.onStart = { [weak self] task in
+      guard let self = self else { return }
       self.requestInFlight = true
       self.onStartHandler(with: task)
     }
     
-    lazyImageView.onProgress = { progress in
+    lazyImageView.onProgress = { [weak self] progress in
+      guard let self = self else { return }
       self.onProgressHandler(with: progress)
     }
     
-    lazyImageView.onSuccess = { response in
+    lazyImageView.onSuccess = { [weak self] response in
+      guard let self = self else { return }
       self.requestInFlight = false
       self.onSuccessHandler(with: response)
     }
     
-    lazyImageView.onFailure = { error in
+    lazyImageView.onFailure = { [weak self] error in
+      guard let self = self else { return }
       self.onFailureHandler(with: error)
     }
     
-    lazyImageView.onCompletion = { result in
+    lazyImageView.onCompletion = { [weak self] result in
+      guard let self = self else { return }
       self.onCompletionHandler(with: result)
 #if !os(tvOS) && canImport(VisionKit)
       if self.enableLiveTextInteraction {
         self.handleLiveTextInteraction()
       }
 #endif
-    }
+  }
+}
     
   }
   

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-turbo-image",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Performant image for React native",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",


### PR DESCRIPTION
## Description

1) I'm like 99% sure there's a memory leak in the iOS version of turbo image
a) TurboImageView has a strong reference to lazyImageView which has a strong reference to the onStart, onPress, etc callbacks
b) Each closure has a strong reference *back* to TurboImageView through the use of "self"
2) To fix this, I'm specify "weak self" in the capture list and adding guards for self in case TurboImageView is deinit'd before the callback is called (e.g. if the image load takes a while)

## Test plan

I scrolled the picks tab up and down several times and opened the memory graph.  In the before version, you can see hundreds of TurboImageView still in memory, but the after version only has 55.

### Before

https://github.com/user-attachments/assets/59c32284-d6c2-41c8-abd5-c2ada0544b94

You can also see the circular reference in the memory graph:

<img width="858" height="870" alt="turboimage-cycle" src="https://github.com/user-attachments/assets/7a466c6b-81b9-4e6d-9d00-5847702a9d08" />

Just as an extra check, I also tried overriding deinit in TurboImageView and adding a print statement there.  The print statement never got triggered.

### After

https://github.com/user-attachments/assets/4d8ac462-6318-4cde-960b-7939134ead81
