### PR TITLE
When decoding an image with coil, default to the UI element's view size instead of the original source image dimensions.

### DIFF
--- a/android/src/main/java/com/turboimage/TurboImageViewManager.kt
+++ b/android/src/main/java/com/turboimage/TurboImageViewManager.kt
@@ -141,7 +141,7 @@ class TurboImageViewManager : SimpleViewManager<TurboImageView>(), LifecycleEven
           error(view.thumbhashDrawable ?: view.blurhashDrawable)
         }
       }
-      size(view.resize ?: Size.ORIGINAL)
+      view.resize?.let { size(it) }
       // attach progress id so interceptor can route updates
       headers(
         (view.headers ?: Headers.Builder().build()).newBuilder()

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-turbo-image",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Performant image for React native",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",


### PR DESCRIPTION
Currently, we're running into crashes in production when super large images are displayed on android. Turns out that although coil is optimized to shrink those images down to fit the view dimensions, a bug in the turbo image library instead explicitly resized all images to their original size, much larger than the actual view they were rendered in. Probably was introduced by accident when a customizable `resize` prop was added.

Simple fix is to only resize the view if the `resize` property exists. Otherwise, do nothing.