### PR TITLE
Add resizeWidth and resizeHeight params to resize large images

### DIFF
--- a/android/src/main/java/com/turboimage/TurboImageViewManager.kt
+++ b/android/src/main/java/com/turboimage/TurboImageViewManager.kt
@@ -230,10 +230,12 @@ class TurboImageViewManager : SimpleViewManager<TurboImageView>(), LifecycleEven
     }
   }
 
+  // TODO: implement this
   @ReactProp(name = "resizeWidth")
   fun setResizeWidth(view: TurboImageView, resizeWidth: Int?) {
   }
 
+  // TODO: implement this
   @ReactProp(name = "resizeHeight")
   fun setResizeHeight(view: TurboImageView, resizeHeight: Int?) {
   }

--- a/android/src/main/java/com/turboimage/TurboImageViewManager.kt
+++ b/android/src/main/java/com/turboimage/TurboImageViewManager.kt
@@ -230,6 +230,14 @@ class TurboImageViewManager : SimpleViewManager<TurboImageView>(), LifecycleEven
     }
   }
 
+  @ReactProp(name = "resizeWidth")
+  fun setResizeWidth(view: TurboImageView, resizeWidth: Int?) {
+  }
+
+  @ReactProp(name = "resizeHeight")
+  fun setResizeHeight(view: TurboImageView, resizeHeight: Int?) {
+  }
+
   @ReactProp(name = "tint")
   fun setTint(view: TurboImageView, tint: Int?) {
     view.tint = tint

--- a/ios/TurboImageView.swift
+++ b/ios/TurboImageView.swift
@@ -65,6 +65,10 @@ final class TurboImageView : UIView {
   @objc var monochrome: UIColor!
   
   @objc var resize: NSNumber?
+    
+  @objc var resizeWidth: NSNumber?
+    
+  @objc var resizeHeight: NSNumber?
   
   @objc var tint: UIColor!
   
@@ -300,9 +304,15 @@ fileprivate extension TurboImageView {
   func composeProcessors() -> [ImageProcessing] {
     var initialProcessors: [ImageProcessing] = []
     
-    if let resize {
+    if let resizeWidth, let resizeHeight {
       initialProcessors.append(
-        ImageProcessors.Resize(width: resize.doubleValue))
+        ImageProcessors.Resize(size: CGSize(width: resizeWidth.doubleValue, height: resizeHeight.doubleValue), contentMode: .aspectFit))
+    } else if let width = resize ?? resizeWidth {
+      initialProcessors.append(
+         ImageProcessors.Resize(width: width.doubleValue))
+    } else if let resizeHeight {
+        initialProcessors.append(
+            ImageProcessors.Resize(height: resizeHeight.doubleValue))
     }
     
     if rounded {
@@ -372,7 +382,7 @@ fileprivate extension TurboImageView {
         self.handleLiveTextInteraction()
       }
 #endif
-    }    
+    }
   }
   
   func onStartHandler(with task: ImageTask) {

--- a/ios/TurboImageView.swift
+++ b/ios/TurboImageView.swift
@@ -198,7 +198,7 @@ final class TurboImageView : UIView {
     }
     lazyImageView.processors = processors
     
-    if !Set(["source", "resize", "blur","monochrome", "tint"])
+    if !Set(["source", "resize", "resizeWidth", "resizeHeight", "blur","monochrome", "tint"])
       .intersection(changedProps).isEmpty {
       reloadImage()
     }

--- a/ios/TurboImageViewManager.m
+++ b/ios/TurboImageViewManager.m
@@ -26,6 +26,10 @@ RCT_EXPORT_VIEW_PROPERTY(monochrome, UIColor *)
 
 RCT_EXPORT_VIEW_PROPERTY(resize, NSNumber)
 
+RCT_EXPORT_VIEW_PROPERTY(resizeWidth, NSNumber)
+
+RCT_EXPORT_VIEW_PROPERTY(resizeHeight, NSNumber)
+
 RCT_EXPORT_VIEW_PROPERTY(tint, UIColor *)
 
 RCT_EXPORT_VIEW_PROPERTY(enableLiveTextInteraction, BOOL)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-turbo-image",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "Performant image for React native",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",

--- a/src/TurboImage.tsx
+++ b/src/TurboImage.tsx
@@ -43,6 +43,8 @@ const TurboImageView = forwardRef(
       blur,
       monochrome,
       resize,
+      resizeWidth,
+      resizeHeight,
       tint,
       enableLiveTextInteraction,
       isProgressiveImageRenderingEnabled,
@@ -95,6 +97,8 @@ const TurboImageView = forwardRef(
           blur={blur}
           monochrome={processColor(monochrome)}
           resize={resize}
+          resizeWidth={resizeWidth}
+          resizeHeight={resizeHeight}
           tint={processColor(tint)}
           enableLiveTextInteraction={enableLiveTextInteraction}
           allowHardware={allowHardware}

--- a/src/types.ts
+++ b/src/types.ts
@@ -67,6 +67,8 @@ export interface TurboImageProps extends AccessibilityProps, ViewProps {
   blur?: number;
   monochrome?: number | ColorValue;
   resize?: number;
+  resizeWidth?: number;
+  resizeHeight?: number;
   tint?: number | ColorValue;
   cachePolicy?: CachePolicy;
   enableLiveTextInteraction?: boolean;


### PR DESCRIPTION
1) This adds 2 params to enable image downsampling to reduce the memory usage of large images.  
2) We can/should also replace the source override images to more reasonable sizes, but this should also handle any random user-generated large images (like through the web fantasy page)
3) Using the existing width param doesn't' work because it will just resizes width and uses a hardcoded height of 9999 (https://github.com/kean/Nuke/blob/main/Sources/Nuke/Processing/ImageProcessors%2BResize.swift#L49)

This is the memory usage when scrolling through the picks page (which has 2 override images for Steph Curry and Kevin Durant), using this PR: https://github.com/blitzstudios/sleeperbot/pull/14213

Before:
<img width="1755" height="540" alt="Screenshot 2025-10-27 at 3 09 53 PM" src="https://github.com/user-attachments/assets/d602c00b-07d0-4ba4-b35b-e4825baf7f37" />

After
<img width="1732" height="578" alt="Screenshot 2025-10-27 at 3 07 26 PM" src="https://github.com/user-attachments/assets/7209f829-acc2-4e73-b27a-e76b9f413f14" />