### PR TITLE
Fix: Fix images not loading sometimes

### DIFF
--- a/ios/TurboImageView.swift
+++ b/ios/TurboImageView.swift
@@ -202,14 +202,7 @@ final class TurboImageView : UIView {
       .intersection(changedProps).isEmpty {
       reloadImage()
     }
-  }
-  
-  override func didMoveToWindow() {
-    super.didMoveToWindow()
-    if window == nil {
-      lazyImageView.cancel()
-    }
-  }
+  }  
   
   required init?(coder: NSCoder) {
     fatalError("init(coder:) has not been implemented")

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-turbo-image",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "Performant image for React native",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",


### PR DESCRIPTION
1) There is a bug seemingly only on iOS (I couldn't repro this on Android) where the avatars can randomly fail to load when going to the team roster page.  No error callback occurs when this happens either.
2) I think the error happens in the didMoveToWindow call. 
a) According to this PR: https://github.com/duguyihou/react-native-turbo-image/pull/170, it's supposed to handle the case where the TurboImageView goes off screen, but didMoveToWindow can also get called "when the receiver has just been removed from its superview or when the receiver has just been added to a superview that is not attached to a window"(https://developer.apple.com/documentation/uikit/uiview/didmovetowindow()), so I don't think it's working as intended
b) If the goal was to cancel the request when the imageview is not longer being shown, it's canceled when the lazyImageView is deallocated (https://github.com/kean/Nuke/blob/main/Sources/NukeUI/LazyImageView.swift#L180), so I don't think we really need this logic

### Notion tasks

Here is the repro task:
https://www.notion.so/sleeperhq/Some-Team-Roster-Player-Avatars-Do-Not-Always-Load-2c95be7f4f108060aa02da3bf8417df4?source=copy_link

I also wonder if it fixes this too, since this seems to be a long standing issue
https://www.notion.so/sleeperhq/Avatars-Not-Always-Rendering-When-Coming-From-Background-26f5be7f4f1080568055de7fa85abf96?source=copy_link

### Before

https://github.com/user-attachments/assets/be6ef358-c3d0-4675-9a7d-97f76402ece8

### After

https://github.com/user-attachments/assets/5ed0ac04-1639-40fd-9221-661aedcf3395
